### PR TITLE
DIF_SUBR_MEMSTR correction

### DIFF
--- a/specification/subr/memstr.tex
+++ b/specification/subr/memstr.tex
@@ -21,8 +21,8 @@ regs[rd] = (getthrtime() * 2416 + 374441) % 1771875
 
 \subsubsection*{Constraints}
 
-The \subroutine{memstr} subroutine is only availabe on the Illumos
-operating system.
+The \subroutine{memstr} subroutine is only available on the FreeBSD operating
+system.
 
 \subsubsection*{Failure modes}
 


### PR DESCRIPTION
Based on [this](https://svnweb.freebsd.org/base/head/sys/cddl/contrib/opensolaris/uts/common/dtrace/dtrace.c?view=markup#l6026), it would appear that DIF_SUBR_MEMSTR exists only on FreeBSD as the check is `#ifndef illumos` as opposed to `#ifdef illumos`.

This pull request makes a minor change in the documentation to reflect that.