### PR TITLE
Further explain LD* instructions

### DIFF
--- a/specification/instr/ldsb.tex
+++ b/specification/instr/ldsb.tex
@@ -20,8 +20,10 @@
 
 \subsubsection*{Description}
 
-The \instruction{ldsb} instruction loads the value pointed to by
-\registerop{r1} into \registerop{rd}, the results register.
+The \instruction{ldsb} instruction loads the value pointed to by \registerop{r1}
+into \registerop{rd}, the results register. This instruction is a
+\textbf{signed} instruction and will perform sign extension on the resulting
+register when applicable.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/ldsh.tex
+++ b/specification/instr/ldsh.tex
@@ -21,7 +21,9 @@
 \subsubsection*{Description}
 
 The \instruction{ldsh} instruction loads a 16-bit value pointed to by
-\registerop{r1} into \registerop{rd}, the results register.
+\registerop{r1} into \registerop{rd}, the results register. This instruction is
+a \textbf{signed} instruction and will perform sign extenstion on the resulting
+register when applicable.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/ldsw.tex
+++ b/specification/instr/ldsw.tex
@@ -20,8 +20,10 @@
 
 \subsubsection*{Description}
 
-The \instruction{ldsb} instruction loads a 32-bit value pointed to by
-\registerop{r1} into \registerop{rd}, the results register.
+The \instruction{ldsw} instruction loads a 32-bit value pointed to by
+\registerop{r1} into \registerop{rd}, the results register. This instruction is
+a \textbf{signed} instruction and will perform sign extension on the resulting
+register when applicable.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/ldub.tex
+++ b/specification/instr/ldub.tex
@@ -20,8 +20,9 @@
 
 \subsubsection*{Description}
 
-The \instruction{ldub} instruction loads the value pointed to by
-\registerop{r1} into \registerop{rd}, the results register.
+The \instruction{ldub} instruction loads the value pointed to by \registerop{r1}
+into \registerop{rd}, the results register. This is an \textbf{unsigned}
+instruction and will not perform sign extension in any case.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/lduh.tex
+++ b/specification/instr/lduh.tex
@@ -21,7 +21,8 @@
 \subsubsection*{Description}
 
 The \instruction{lduh} instruction loads a 16-bit value pointed to by
-\registerop{r1} into \registerop{rd}, the results register.
+\registerop{r1} into \registerop{rd}, the results register. This is an
+\textbf{unsigned} instruction and will not perform sign extension in any case.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/lduw.tex
+++ b/specification/instr/lduw.tex
@@ -20,9 +20,9 @@
 
 \subsubsection*{Description}
 
-The \instruction{ldsb} instruction loads an unsigned 32-bit value
-pointed to by \registerop{r1} into \registerop{rd}, the results
-register.
+The \instruction{lduw} instruction loads a 32-bit value pointed to by
+\registerop{r1} into \registerop{rd}, the results register. This is an
+\textbf{unsigned} instruction and will not perform sign extension in any case.
 
 \subsubsection*{Pseudocode}
 

--- a/specification/instr/ldx.tex
+++ b/specification/instr/ldx.tex
@@ -21,7 +21,8 @@
 \subsubsection*{Description}
 
 The \instruction{ldx} instruction loads a 64 bit value pointed to by
-\registerop{r1} into \registerop{rd}.
+\registerop{r1} into \registerop{rd}. Much like conventional RISC architectures,
+it does not perform sign extension, as this is considered to be the widest type.
 
 \subsubsection*{Pseudocode}
 


### PR DESCRIPTION
It might not be obvious to the reader that `LDSB`, `LDSH` and `LDSW` perform sign extension on their arguments when returning the value in the `rd` register.

Elaborate that in the documentation of those instructions and explain why sign extension is not done in the `LDX` instruction.

This pull request contains the aforementioned explanations and some typo corrections in the existing text.