### PR TITLE
Correct some statements

### DIFF
--- a/specification/chap-opendtrace-intermediate-format.tex
+++ b/specification/chap-opendtrace-intermediate-format.tex
@@ -199,25 +199,25 @@ instruction.
 A modified version of the Register Format is used when loading and
 storing data in array variables in DTrace. The main difference between the
 regular Register Format and the modified one used for arrays, is that the
-\registerop{r1} register location is used as the variable identificator, and the
-\registerop{r2} register location is used as an optional index in the array.
+\registerop{r1} register location is used as the variable identificator, the
+\registerop{r2} register itself contains the optional index in the array.
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31}\\
 \bitbox{8}{op}
 \bitbox{8}{var}
-\bitbox{8}{ndx}
+\bitbox{8}{r2}
 \bitbox{8}{rd}
 \end{bytefield}
 \end{center}
 
 \begin{description}
-	\item[op] Mandatory 8-bit operation identifier
-	\item[var] The variable identifier
-	\item[ndx] Optional index of the array variable to be accessed
-	\item[rd] Optional destination register acting as the destination of the
-operation
+\item[op] Mandatory 8-bit operation identifier
+\item[var] The variable identifier
+\item[r2] Optional register that contains the index of the array
+\item[rd] Optional destination register acting as the destination of the
+  operation
 \end{description}
 
 \subsection{Branch Format (B-Format)}

--- a/specification/instr/ldga.tex
+++ b/specification/instr/ldga.tex
@@ -6,14 +6,14 @@
 
 \subsubsection*{Format}
 
-\textrm{LDGA \%rd, var, index}
+\textrm{LDGA \%rd, var, \%r2}
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31}\\
 \bitbox{8}{op}
 \bitbox{8}{var}
-\bitbox{8}{ndx}
+\bitbox{8}{r2}
 \bitbox{8}{rd}
 \end{bytefield}
 \end{center}
@@ -22,14 +22,16 @@
 
 The \instruction{ldga} instruction looks up the value of a DTrace
 built-in variable based on the value in \registerop{var} with an
-optional array index in \registerop{ndx}. \\
+optional array index in the register \register{r2}. \\
 
 Unlike the \instruction{ldgs}, the variable identifier is 8 bits long, and
-the other 8 bits are used to act as an array index.
+the other 8 bits are used to identify the register which contains the index of
+the array.
 
 \subsubsection*{Pseudocode}
 
 \begin{verbatim}
+index = %r2
 %rd = var[index]
 \end{verbatim}
 

--- a/specification/instr/ldta.tex
+++ b/specification/instr/ldta.tex
@@ -6,13 +6,13 @@
 
 \subsubsection*{Format}
 
-\textrm{LDTA \%rd, \%r1, \%r2}
+\textrm{LDTA \%rd, var, \%r2}
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31} \\
 \bitbox{8}{0x2B}
-\bitbox{8}{r1}
+\bitbox{8}{var}
 \bitbox{8}{r2}
 \bitbox{8}{rd}
 \end{bytefield}


### PR DESCRIPTION
This pull request corrects some of the statements that I've made before regarding LDGA and the modified register format.

Through writing compiler tests, it has become evident that this information was wrong and that in fact, a register is used to store an array index in LDGA and LDTA.