### PR TITLE
Fixes in the instruction definition and description

### DIFF
--- a/specification/instr/pushtr.tex
+++ b/specification/instr/pushtr.tex
@@ -6,15 +6,15 @@
 
 \subsubsection*{Format}
 
-\textrm{PUSHTR \%rd, \%r1, \%r2}
+\textrm{PUSHTR type, \%r2, \%rs}
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31} \\
 \bitbox{8}{0x30}
-\bitbox{8}{r1}
+\bitbox{8}{type}
 \bitbox{8}{r2}
-\bitbox{8}{rd}
+\bitbox{8}{rs}
 \end{bytefield}
 \end{center}
 
@@ -27,11 +27,15 @@ value is stored.
 
 \subsubsection*{Pseudocode}
 
-The following code shows a string being pushed by value.
-
 \begin{verbatim}
-stack[++index].size = strlen(%rd);
-stack[index].value = %rd
+value = %rs
+if type is string:
+    size = strlen(value)
+else:
+    size = %r2
+
+stack[++index].size = size
+stack[index].value = value
 \end{verbatim}
 
 \subsubsection*{Constraints}

--- a/specification/instr/pushtr.tex
+++ b/specification/instr/pushtr.tex
@@ -21,7 +21,7 @@
 \subsubsection*{Description}
 
 The \instruction{pushtr} instruction pushes a reference, contained in
-the \registerop{rd} register onto the stack.  The length is stored for
+the \registerop{rs} register onto the stack.  The length is stored for
 a string along with the value.  For a numeric value the size of that
 value is stored.
 

--- a/specification/instr/pushtv.tex
+++ b/specification/instr/pushtv.tex
@@ -6,15 +6,15 @@
 
 \subsubsection*{Format}
 
-\textrm{PUSHTV \%rd, \%r1, \%r2}
+\textrm{PUSHTV type, \%r0, \%rs}
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31} \\
 \bitbox{8}{0x31}
-\bitbox{8}{r1}
-\bitbox{8}{r2}
-\bitbox{8}{rd}
+\bitbox{8}{type}
+\bitbox{8}{r0}
+\bitbox{8}{rs}
 \end{bytefield}
 \end{center}
 
@@ -28,7 +28,7 @@ along with the value.
 \subsubsection*{Pseudocode}
 
 \begin{verbatim}
-stack[++index].value = %rd
+stack[++index].value = %rs
 stack[index] = 0;
 \end{verbatim}
 

--- a/specification/instr/pushtv.tex
+++ b/specification/instr/pushtv.tex
@@ -21,7 +21,7 @@
 \subsubsection*{Description}
 
 The \instruction{pushtv} instruction takes the value contained in
-\registerop{rd} register and pushes it onto the stack.  Unlike the
+\registerop{rs} register and pushes it onto the stack.  Unlike the
 \verb|PUSHTR| instruction, the size of the value is \emph{not} stored
 along with the value.
 

--- a/specification/instr/sra.tex
+++ b/specification/instr/sra.tex
@@ -2,7 +2,7 @@
 \phantomsection
 \addcontentsline{toc}{subsection}{SRA}
 \label{insn:sra}
-\subsection*{SRA: Shift right}
+\subsection*{SRA: Shift Right Arithmetic}
 
 \subsubsection*{Format}
 
@@ -20,8 +20,9 @@
 
 \subsubsection*{Description}
 
-The \instruction{sra} instruction shifts the value in \registerop{r1}
-right by the number of bits indicated in \registerop{r2}.
+The \instruction{sra} instruction shifts the value in \registerop{r1} right by
+the number of bits indicated in \registerop{r2}, placing the results in register
+\registerop{rd}.  This instruction only operates on \textbf{signed} integers.
 
 \subsubsection*{Pseudocode}
 
@@ -30,6 +31,13 @@ right by the number of bits indicated in \registerop{r2}.
 \end{verbatim}
 
 \subsubsection*{Constraints}
+
+\registerop{r1}, \registerop{r2}, and \registerop{rd} must be less than
+\nregs{}.
+
+\medskip
+\noindent
+\registerop{rd} cannot be \register{r0}.
 
 \subsubsection*{Failure modes}
 

--- a/specification/instr/srl.tex
+++ b/specification/instr/srl.tex
@@ -22,7 +22,8 @@
 
 This instruction shifts the value found in regiseter \register{r1} right by
 the number of bits found in register \register{r2}, placing the results in
-register \register{rd}.
+register \register{rd}. This instruction only operates on \textbf{unsigned}
+integers.
 
 \subsubsection*{Pseudocode}
 


### PR DESCRIPTION
This pull request changes a couple of major problems in describing SRL and SRA, as well as updates the pseudocode/descriptor for PUSHTR and PUSHTV to be more generic.