### PR TITLE
PUSHTV fix

### DIFF
--- a/specification/instr/pushtv.tex
+++ b/specification/instr/pushtv.tex
@@ -6,13 +6,13 @@
 
 \subsubsection*{Format}
 
-\textrm{PUSHTV type, \%r0, \%rs}
+\textrm{PUSHTV \%rs}
 
 \begin{center}
 \begin{bytefield}[endianness=big,bitformatting=\scriptsize]{32}
 \bitheader{0,7,8,15,16,23,24,31} \\
 \bitbox{8}{0x31}
-\bitbox{8}{type}
+\bitbox{8}{r0}
 \bitbox{8}{r0}
 \bitbox{8}{rs}
 \end{bytefield}
@@ -29,7 +29,7 @@ along with the value.
 
 \begin{verbatim}
 stack[++index].value = %rs
-stack[index] = 0;
+stack[index].size = 0;
 \end{verbatim}
 
 \subsubsection*{Constraints}


### PR DESCRIPTION
The implementation of PUSHTV just assumes that we pass in r0, which is fixed as 0 as the other arguments in order to format the instruction properly, however, we never actually write the instruction in that form explicitly.

This pull request writes out the instruction correctly and fixes an error in the pseudocode where size wasn't written.