### PR TITLE
Clarify how the DIF interpreter works

### DIFF
--- a/specification/chap-opendtrace-intermediate-format.tex
+++ b/specification/chap-opendtrace-intermediate-format.tex
@@ -7,20 +7,20 @@ shipped in Solaris \textbf{XXXRW}, FreeBSD \textbf{XXXRW}, and Mac OS X
 
 \section{The DIF Interpreter}
 
-The DTrace Intermediate Format (DIF) interpreter executes instructions
-on behalf of D scripts that are associated with predicates and
-actions.  DIF is a simple, RISC-like, instruction set where each
-instruction consists of a 32-bit, native-endian integer whose most
-significant 8 bits contain an opcode allowing the remainder of the
-instruction to be decoded.  Interpretation is executed in a loop
-within the \function{dtrace_dif_emulate} function, which has, as
-its first argument, a pointer to a DIF Object or
-\struct{dtrace_difo_t}.  Instructions are executed one at a time,
-until they are exhausted or an error causes interpretation to end. The DIF
-objects are verified in the \function{dtrace_difo_validate} function and
-the DIF interpreter ignores any bounds checking within the
-\function{dtrace_dif_emulate} function precisely because
-\function{dtrace_difo_validate} performs the necessary checks.
+The DTrace Intermediate Format (DIF) interpreter executes instructions on behalf
+of D scripts that are associated with predicates and actions.  DIF is a simple,
+RISC-like, instruction set where each instruction consists of a 32-bit,
+native-endian integer whose most significant 8 bits contain an opcode allowing
+the remainder of the instruction to be decoded.  Interpretation is executed in a
+loop within the \function{dtrace_dif_emulate} function, which has, as its first
+argument, a pointer to a DIF Object or \struct{dtrace_difo_t}. Each of the DIF
+Object gets executed in its own separtate environment and must return a value
+using the \instruction{ret} instruction. Instructions are executed one at a
+time, until they are exhausted or an error causes interpretation to end. The DIF
+objects are verified in the \function{dtrace_difo_validate} function and the DIF
+interpreter ignores any bounds checking within the \function{dtrace_dif_emulate}
+function precisely because \function{dtrace_difo_validate} performs the
+necessary checks.
 
 \subsection{Registers}
 \label{sec:dif-registers}


### PR DESCRIPTION
This pull request adds the explicitly statement that each DIF Object gets executed as a sort of a "function" in DIF and must return.