### PR TITLE
Spelling fixes on the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Current version of the [OpenDTrace
 Specification](https://github.com/opendtrace/documentation/blob/master/specification/opendtrace-specification.pdf)
 
 In order to checkout and build the specification you will need a full
-installation of a modern (La)Tex system including the following
+installation of a modern (La)TeX system including the following
 packages:
 
   * algpseudocode
@@ -26,4 +26,4 @@ packages:
   * times
 
 Once LaTeX and the packages are installed you can build the document
-by typeing `make` in the `specification/` directory.
+by typing `make` in the `specification/` directory.


### PR DESCRIPTION
Nothing major:
- spell TeX correctly
- s/typeing/typing/