### PR TITLE
Wording/removing references to code/grammar

### DIFF
--- a/specification/chap-intro.tex
+++ b/specification/chap-intro.tex
@@ -206,4 +206,11 @@ This report specifies a number of aspects of OpenDTrace's operation:
 %   implemented through an operating system thread, it should be thought of as an abstract thread
 %   with some abstract notion of an identifier. It may contain far more in its identifier than just
 %   what the operating system provides.}
+% \item[DTrace action] A sequence of instructions which are a part of the DTrace run time enviornment.
+% \item[Probe clause] A sequence of DTrace actions.
+% \item[Probe] A sequence of probe clauses with a unique identifier with arbitrary interleaving of its
+%   contained DTrace actions with any other probe, including itself.
+% \item[Probe firing] The beginning of execution of probe clauses.
+% \item[DTrace failure] In a given probe, one or more clauses could not be executed with the desired
+%   semantics (this will be elaborated on further in the relevant chapters).
 % \end{description}

--- a/specification/chap-opendtrace-arch.tex
+++ b/specification/chap-opendtrace-arch.tex
@@ -125,27 +125,18 @@ as for each action statement in a D language clause.
 The ECBs are provided to the kernel module (3c) which stores them,
 with others, in a tree like structure. Once an ECB is safely stored in
 the kernel, the kernel module tells the provider to enable the probes
-that are to be instrumented.
-
-Enabling a probe means telling the provider that at the right point
-the \verb|dtrace_probe| kernel function must be called.  All tracing
-ultimately goes through the \verb|dtrace_probe| function in the
-kernel, which is responsible for all of the work related to any part
-of tracing.  How \verb|dtrace_probe| is ultimately called depends on
-both the program and the provider.
+that are to be instrumented. Enabling a probe means telling the provider
+that at the right point, decided by the provider, the control will be
+transferred to DTrace.
 
 The function boundary tracepoint (\verb|fbt|) and \verb|fasttrap|
 providers which allow tracing of kernel code and user space code,
 respectively, both operate under the same model.  They both find the
 instruction in the program at which the tracepoint is to be placed and
 swap the regular instruction with a an architecture dependent
-break-point instruction when tracing is enabled.
-
-The profile provider is completely different from the FBT or fasttrap
-providers as it is meant to call \verb|dtrace_probe| on a periodic
-basis using in-kernel timers.  Enabling a profile provider does not
-change any instruction stream in any program, but instead adds calls
-to \verb|dtrace_probe| to the kernel's timing machinery.
+break-point instruction when tracing is enabled. The profile provider is
+completely different from the \verb|fbt| or \verb|fasttrap| providers as
+it fires its probes on a periodic basis.
 
 When code execution reaches a point that has an enabled probe, the
 probe fires and a call is made into the kernel module (5). The kernel
@@ -162,12 +153,13 @@ When tracing is enabled the OpenDTrace modules in the kernel produce a
 stream of records which are consumed by user level processes, such as
 the \verb|dtrace(1)| command, and turned into various types of output.
 
-Records are communicated in a buffer structure, \verb|dtrace_bufdata|
+Records are communicated in a buffer structure
 which is shared between the kernel and user space.  Buffers contain
 one of two types of data.  Either the data is a plain record, or it is
 an aggregation.  All data is arranged as a stream of bytes where the
 current header gives the extent of the data, indicating where the next
-record can be found.
+record can be found. The details of the buffer structure are described in
+Chapter~\ref{chap:opendtrace-trace-buffer}.
 
 Plain records contain the data requested by the D script along with
 optional formatting information and arguments.  Aggregations are
@@ -178,10 +170,13 @@ and information on data binning.
 \section{Privilege Model}
 \label{sec:privilege}
 
+% XXXDS: Avoid any mention of ``root'' or any other privilege models,
+% we just care that the user is privileged w.r.t. the provider. Nothing
+% else.
+
 The OpenDTrace privilege model is relatively simple, any program that
 wishes to trace another program, or the operating system kernel, must
-be running with \emph{root} privileges.  Some operating systems, such
-as Illumos, provide a more nuanced privilege model.
+be a privileged user from the perspective of each provider.
 
 %%% Local Variables:
 %%% mode: latex

--- a/specification/chap-opendtrace-dlang.tex
+++ b/specification/chap-opendtrace-dlang.tex
@@ -319,7 +319,14 @@ as:
              \alt <Expression> `?' <Expression> `:' <Expression>
              \alt <Subroutine> `(' <SubroutineArgs> `)'
              \alt <ThisOrSelf> <Identifier> [ `[' <ArrayIndices> `]' ]
-             \alt <IdentifierOrString> ;
+             \alt <IdentifierOrString>
+             \alt <XLate> ;
+
+<XLate> ::= `xlate <' <Type> `>' `(' <XLateMethod> `)' ;
+
+<XLateMethod> ::=  <Subroutine> `(' <SubroutineArgs> `)'
+              \alt <IdentifierOrString> ;
+
 
 <AggExpression> ::=  `@' [ <Identifier> ] [ `[' <ArrayIndices> `]' ] `=' <AggFunc> ;
                 \alt <AggSubroutine> `(' <AggSubroutineArgs> `)' ;
@@ -363,16 +370,14 @@ that can be run on the D script, as how this will be implemented and
 what parts of it will be supported is entirely up to the compiler
 writer. We define the D script as follows:
 \begin{grammar}
+<VarDecl> ::= <Modifier> <Type> <Identifier> [ `[' <Type> <Identifier> `]' ] ;
+
 <DScript> ::=  <DScript> <PreprocessorStatement> <DScript>
           \alt <DScript> <TypeSpecifier> <DScript>
           \alt <DScript> <ProbeDefinition> <DScript>
-          \alt <DScript> <XLate>  <DScript>
+          \alt <DScript> <VarDecl> [ `=' <Expression> ] <DScript>
+          \alt `;'
           \alt `' ;
-
-<XLateMethod> ::=  <Subroutine> `(' <SubroutineArgs> `)'
-              \alt <IdentifierOrString> ;
-
-<XLate> ::= <Modifier> <Type> <Identifier> [ `[' <Type> <Identifier> `]' ] = `xlate <' <Type> `>' `(' <XLateMethod> `)' `;' ;
 \end{grammar}
 
 \section{Safety}

--- a/specification/chap-opendtrace-intermediate-format.tex
+++ b/specification/chap-opendtrace-intermediate-format.tex
@@ -103,31 +103,17 @@ Format described in Subsection~\ref{subsec:b-format}.
 \subsection{Subroutine Calls}
 \label{sec:subroutines}
 
-OpenDTrace provides an extensive set of subroutines for use by D programs.
-The subroutines are implemented within the kernel code via a set of
-functions which are centrally dispatched from the
-\function{dtrace_dif_subr} function.  Within DIF subroutines are
-triggered via the \instruction{CALL} instruction. The arguments to
-these subroutines are passed through the \verb|tupregs| variable
-through use of the \instruction{PUSHTR} and \instruction{PUSHTV}
-instructions. The return values of the subroutines are provided
+Within DIF subroutines are triggered via the \instruction{CALL} instruction.
+The arguments to these subroutines are passed through the tuple stack.
+The tuple stack itself is populated using \verb|pushtr| and \verb|pushtv|
+instructions and the return values of the subroutines are provided
 through the \registerop{rd} register. The subroutine identifier is
 placed in the \registerop{idx} field of the wide-immediate format (W-Format)
 described in Subsection~\ref{subsec:w-format}. Any subroutine that is provided
-to DTrace \emph{must} go via these mechanisms.
-
-\begin{quote}
-  Notice that we don't bother validating the proper number of
-  arguments or their types in the tuple stack.  This isn't needed
-  because all argument interpretation is safe because of our load
-  safety -- the worst that can happen is that a bogus program can
-  obtain bogus results.
-\label{fig:argcheck}
-\end{quote}
-
-According to a comment in the code, see Figure~\ref{fig:argcheck}, argument
-checks are not carried out when a subroutine is called. These checks are
-performed in the \function{dtrace_difo_validate} function at load time.
+to DTrace \emph{must} go via these mechanisms. None of the arguments to subroutines
+need to be validated before calling the subroutine, as they originate from the
+previously validated data using other DIF instructions which themselves have
+validated this data beforehand.
 
 % \textbf{XXXDS: Are these comments related to the Subroutine Calls section, or
 % overall?}
@@ -154,33 +140,23 @@ Additionally, variables are identified using the modified register format as des
 in Subsection~\ref{subsec:r-format} when working with arrays and the W-Format described
 in Subsection~\ref{subsec:w-format} when working with scalar variables.
 
-% XXXDS: These are all just implementation details. This isn't really about DIF, it's
-% about the current runtime implementation. We've talked about scalars and arrays just
-% above. For aggregations, it would be useful to talk about the more general idea of
-% DTrace actions instead of just DIF -- but we can say that their arguments are gathered
-% through DIF.
 \subsection{Scalars}
 \label{sec:scalars}
+
+Scalar variables are loaded into registers using \verb|LDGS|,
+\verb|LDTS| and \verb|LDLS| and stored to memory from registers using
+\verb|STGS|, \verb|STTS| and \verb|STLS| for global, thread-local and
+clause-local scalar variables respectively.
 
 \subsection{Arrays}
 \label{sec:arrays}
 
-\subsection{Aggregations}
-\label{sec:dif-aggregations}
-
-% XXXDS: What are exceptions?
-\subsection{Exceptions}
-\label{sec:exceptions}
-
-% The semantics of them have been described in the DLang chapter. The rest are just
-% implementation details that don't really belong here IMO.
-\subsection{Dynamic Variables}
-\label{sec:sec:dynamic-vars}
-
-% From Samuel Lepetit
-% It would be super useful to have a section on how dynamic variables
-% work and how the hashing magic in dtrace_dynvar work for those.
-
+%% FIXME: There are also LDGA and LDTA, which seem to be for built-in variables (args, uregs)
+%% but I'm unable to determine that for sure. I'm not able to generate LDTA yet.
+Similarly to scalar variables, array variables are loaded into registers using
+\verb|LDGAA| and \verb|LDTAA| and stored to using \verb|STGAA| and \verb|STTAA|
+for global and thread-local array variables respectively. Note that there are no
+instructions for clause-local array variables.
 
 \section{Instruction Format}
 

--- a/specification/chap-opendtrace-subroutines.tex
+++ b/specification/chap-opendtrace-subroutines.tex
@@ -6,37 +6,30 @@ called from probe context without risking system safety.
 
 \section{Subroutine calling mechanism}
 
-Every D subroutine exists simultaneously as a part of the D scripting
-language as well as code in the operating system kernel.  D subroutines
-must be coded in such a way that they do not depend on kernel
-services, such as memory allocation, or mutual exclusion primitives,
-which might be inspected as part of a tracing session.
+% FIXME: I don't think we mention the ``safety constraints'' anywhere.
+% Note: We don't want to say the specific things that they are, but instead
+% note that they may depend on the probe...? We've already started changing
+% this.
+Every D subroutine is implemented as a part of the D run time
+environment and must be implemented according to the safety constraints
+that DTrace expects.
 
 When a subroutine appears in a D script it is the responsibility of
 the D code generator to turn the subroutine and its arguments into DIF
-to be passed into the kernel for execution.  All subroutines and their
-arguments are described in a single structure, \verb|_dtrace_globals|
-in the \verb|libdtrace| library.  Each subroutine has a string name,
+to be passed into the DTrace for execution. Each subroutine has a string name,
 an identifier type, a set of flags, a numeric ID, a small set of
-functions, and an argument list.  The argument list defined in the
-\verb|_dtrace_globals| structure is a string which is processed via
-the \verb|dt_open| function into a relevant set of argument types.
+functions, and an argument list.  The argument list defined is processed
+into a relevant set of argument types at the time of opening of the DTrace
+device.
 
-The \verb|DT_INSTR_CALL| instruction is used by the D code generator
-to generate a subroutine call.  Each call instruction has an
-identifier, which is the name of the subroutine, and a set of
-registers which contain the arguments to the call.  The arguments in
-the registers are placed into D's tuple stack for use in kernel
-context.
-
-Once in the kernel all subroutines are executed from a central
-function, \verb|dtrace_dif_subr| which dispatches calls to various,
-OpenDTrace private versions of the functions required.  All of the
-subroutines are implemented using the register state passed into the
-kernel and represented on the tuple stack, or local variables, in
-order to avoid using any of the kernel's memory allocation subsystem.
-All subroutines are executed from probe context (\verb|dtrace_probe|)
-via the \verb|dt_dif_emulate| routine.
+% XXXDS: This had a lot of repetitive points and some wrong names.
+The \verb|DIF_OP_CALL| instruction, described in
+Chapter~\ref{chap-opendtrace-instruction-reference}, is used by the D
+code generator to generate a subroutine call.  Each call instruction just
+has an identifier, which is the name of the subroutine. The arguments are
+placed into D's tuple stack for use in the subroutine. Once in the
+execution context of DTrace all subroutines are executed as a part
+of DIF execution.
 
 \section{Subroutine list}
 \label{sec:subroutine-list}
@@ -192,7 +185,7 @@ The subroutines listed in in order by their index.
 
 The remainder of this chapter describes each of the subroutines
 available in the D language in detail.  The subroutines are arranged
-in alphabetical order.  
+in alphabetical order.
 
 \input{subr/alloca}
 \input{subr/basename}


### PR DESCRIPTION
This pull request fixes some of the grammar and removes references to functions in the code.

It also removes some of the duplicate wording in the spec and attempts to make some things more clear.