### PR TITLE
Provide link to published tech report.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ Papers, technical reports, and other documentation covering OpenDTrace.
 
 ## OpenDTrace Specification
 
-Current version of the [OpenDTrace
-Specification](https://github.com/opendtrace/documentation/blob/master/specification/opendtrace-specification.pdf)
+### Published versions
+
+[v1.0](https://github.com/opendtrace/documentation/releases/tag/v1.0)
+: https://www.cl.cam.ac.uk/techreports/UCAM-CL-TR-924.html
+
+### Current version
 
 In order to checkout and build the specification you will need a full
 installation of a modern (La)TeX system including the following


### PR DESCRIPTION
Since the "current version" link is broken, provide a link to the
published Cambridge Tech Report instead. Also link to the GitHub Release
page for that version.

Closes #32